### PR TITLE
Fix Safari image layout issue and center the checked badge

### DIFF
--- a/src/app/components/image-button/image-button.component.scss
+++ b/src/app/components/image-button/image-button.component.scss
@@ -36,9 +36,10 @@
   position: absolute;
   width: 4rem;
   height: 4rem;
-  bottom: 0px;
-  right: 0px;
+  top: 50%;
+  left: 50%;
   background-color: rgb(255, 153, 0);
   border-radius: 50%;
-  opacity: 0.5;
+  opacity: 0.3;
+  transform: translate(-50%, -50%);
 }

--- a/src/app/components/image-button/image-button.component.scss
+++ b/src/app/components/image-button/image-button.component.scss
@@ -29,7 +29,6 @@
 }
 
 .goods-image {
-  width: 100%;
   height: 100%;
 }
 


### PR DESCRIPTION
The image layout looks fine in Edge/Chrome, but in Safari (macOS and iOS), the images get enlarged and cause layout issues:
<img width="1417" alt="image" src="https://github.com/user-attachments/assets/3e5bb2ba-b18e-4e90-a970-4049c4b7ed87" />
